### PR TITLE
Fix typo in bokscron, add sysreplace toggling

### DIFF
--- a/examples/site.pp
+++ b/examples/site.pp
@@ -1,0 +1,25 @@
+#
+# Example of a full host classification.
+#
+
+include boks
+include ssh
+
+class { 'boks::boks_sshd' : boks_sshd_set_to => 'off', }
+
+class { 'boks::filmon' : filmon_set_to       => 'off',
+                         filmon_runhours     => '23-05',
+                         filmon_filesystems  => '', }
+
+class { 'boks::bksd' : bksd_set_to      => 'on',
+                       bksd_timeout     => 'on',
+                       bksd_sleep       => '30', }
+
+class { 'boks::bokscron' : bokscron_set_to      => 'on', }
+
+class { 'boks::sysreplace' : sysreplace_set_to      => 'on', }
+
+
+# Or for a BoKS master:
+# class { 'boks::master_config' : }
+# class { 'boks::master_actions' : }

--- a/manifests/bokscron.pp
+++ b/manifests/bokscron.pp
@@ -12,7 +12,7 @@ inherits boks
   file_line { 'bokscron':
     ensure  => 'present',
     path    => "${env_file}",
-    line    => "BOKSCRON=${filmon_set_to}",
+    line    => "BOKSCRON=${bokscron_set_to}",
     match   => '^BOKSCRON\=',
     require => Package["${package_name}"],
     notify  => Service["boksm"],

--- a/manifests/sysreplace.pp
+++ b/manifests/sysreplace.pp
@@ -1,0 +1,27 @@
+#
+
+class boks::sysreplace
+(
+$sysreplace_set_to = 'on',
+)
+
+inherits boks
+
+{
+
+  if ${sysreplace_set_to} == "on" {
+    exec { "sysreplace_on":
+      command => '${boks_lib}/sysreplace replace',
+      unless  => 'grep -i "SSM_ACTIVE=true" $env_file',
+      require => Package["${package_name}"],
+    }
+  }
+  else {
+    exec { "sysreplace_off":
+      command => '${boks_lib}/sysreplace restore',
+      onlyif  => 'grep -i "SSM_ACTIVE=true" $env_file',
+      require => Package["${package_name}"],
+    }
+  }
+
+}


### PR DESCRIPTION
Noticed that the bokscron.pp was setting a parameter in ENV to the filmon_set_to param instead of bokscron_set_to. That'll teach me to copy between files.

Also added the option to toggle sysreplace status, through a parameter.
